### PR TITLE
Add draft standard via C headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,29 @@
-# tensor-interfaces
-A place to store information for the tensor discussions and possible specifications.
+TAPP: Tensor Algebra Processing Primitives
+===
+TAPP is a draft for a low-level standard tensor interface, similar to BLAS interface for matrices.
 
-## [Terminology/Notation](terminology.md)
+TAPP defines the interface itself and clarifies the related technicalities. A reference implementation is available [here.](https://github.com/TAPPorg/reference-implementation)
 
-## [Classifying and Specifying Tensor Operations](operations.md)
+TAPP formulates the basic tensor contraction operation as
+```
+D(idx_D) = alpha A(idx_A) * B(idx_B) + beta C(idx_C),
+```
+where A,B,C and D are tensors and alpha, beta scalars. idx_* is an array of indices of the corresponding tensor using the Einstein summation convention, e.g. 
+```
+    int64_t idx_D[3] = {'a', 'd', 'e'};
+    int64_t idx_A[3] = {'a', 'b', 'c'};
+    int64_t idx_B[4] = {'c', 'd', 'e', 'b'};
+    int64_t idx_C[3] = {'a', 'd', 'e'};
+```
+The function TAPP_create_tensor_product in src/tapp/product.h uses this information to create a contraction plan, which is then executed by TAPP_execute_product.
 
-## [Interface Issues](interface.md)
 
-## Proposals
+TAPP was devised following CECAM Workshop on Tensor Contraction Library Standardization which took place in Toulouse May 22-24, 2024. Since then, a working group is meeting regularly to maintain TAPP. 
 
-- [Proposal 1](proposal1.md) (Paul Springer)
-    
-    This is an initial proposal for a mixed-precision tensor contraction interface.
-    
-- [Proposal 2a](proposal2a.md) (Devin Matthews)
+[tensor.sciencesconf.org](https://tensor.sciencesconf.org/)
 
-    Fixed-type tensor contraction interface using Einstein notation.
-    
-- [Proposal 2b](proposal2b.md) (Devin Matthews)
-
-    Fixed-type tensor contraction interface using BLAS-like arguments.
+Please submit all technical questions, suggestions and queries to Issues.
+For other inquiries, you can contact:
+Devin Matthews damatthews at mail.smu.edu 
+Paolo Bientinesi pauldj at cs.umu.se 
+Jan Brandejs jbrandejs at irsamc.ups-tlse.fr 

--- a/src/tapp.h
+++ b/src/tapp.h
@@ -1,0 +1,13 @@
+#ifndef TAPP_TAPP_H_
+#define TAPP_TAPP_H_
+
+#include "tapp/error.h"
+#include "tapp/attributes.h"
+#include "tapp/datatype.h"
+#include "tapp/handle.h"
+#include "tapp/executor.h"
+#include "tapp/status.h"
+#include "tapp/tensor.h"
+#include "tapp/product.h"
+
+#endif /* TAPP_TAPP_H_ */

--- a/src/tapp/attributes.h
+++ b/src/tapp/attributes.h
@@ -1,0 +1,19 @@
+#ifndef TAPP_ATTRIBUTES_H_
+#define TAPP_ATTRIBUTES_H_
+
+#include <stdint.h>
+
+#include "error.h"
+
+typedef intptr_t TAPP_attr;
+typedef int TAPP_key;
+
+//TODO: predefined attributes? error conditions?
+
+TAPP_error TAPP_attr_set(TAPP_attr attr, TAPP_key key, void* value);
+
+TAPP_error TAPP_attr_get(TAPP_attr attr, TAPP_key key, void** value);
+
+TAPP_error TAPP_attr_clear(TAPP_attr attr, TAPP_key key);
+
+#endif /* TAPP_ATTRIBUTES_H_ */

--- a/src/tapp/datatype.h
+++ b/src/tapp/datatype.h
@@ -1,0 +1,95 @@
+#ifndef TAPP_DATATYPE_H_
+#define TAPP_DATATYPE_H_
+
+/*
+ * Storage data types:
+ *
+ * The storage data type is an integer enumeration which indicates the numerical format of tensor data as passed
+ * into or returned from the library. Each tensor has a single storage datatype which describes all elements of
+ * the tensor. Negative values and values less than 0x1000 are reserved by the standard, but values greater than
+ * or equal to 0x1000 may be used by implementations for additional data types.
+ */
+
+typedef int TAPP_datatype;
+
+enum
+{
+    /* IEEE754 float32: 1 sign bit, 8 exponent bits, 23 explicit significand bits */
+    TAPP_F32 = 0,
+
+    /* IEEE754 float64: 1 sign bit, 11 exponent bits, 52 explicit significand bits */
+    TAPP_F64 = 1,
+
+    /* Complex IEEE754 float32, stored with consecutive real and imaginary parts packed into 8 bytes */
+    TAPP_C32 = 2,
+
+    /* Complex IEEE754 float64, stored with consecutive real and imaginary parts packed into 16 bytes */
+    TAPP_C64 = 3,
+
+    /* IEEE754 float16: 1 sign bit, 5 exponent bits, 10 explicit significand bits */
+    TAPP_F16 = 4,
+
+    /* bfloat16: 1 sign bit, 8 exponent bits, 7 explicit significand bits */
+    TAPP_BF16 = 5,
+
+    /* Aliases */
+    TAPP_FLOAT = TAPP_F32,
+    TAPP_DOUBLE = TAPP_F64,
+    TAPP_SCOMPLEX = TAPP_C32,
+    TAPP_DCOMPLEX = TAPP_C64,
+};
+
+/*
+ * Computational precision types:
+ *
+ * The computational precision determines the number of correct significant digits in the multiplication and
+ * accumulation of scalar floating-point types. The computational precision also typically determines the conversion
+ * of data to/from storage data types into an internal representation which may or may not be another storage data
+ * type. The names of the precision type values are of the form TAPP_XXXYYY_ACCUM_ZZZ, where XXX and YYY indicate
+ * the precision of the input scalars before multiplication, and ZZZ indicates the precision of the product after
+ * accumulation. Note that when fused-multiply-add (FMA) instructions are available, the precision of the intermediate
+ * product is "infinite". Low-precision computations, e.g. float16, may be performed in a higher precision when
+ * hardware support is not available. The default precision TAPP_DEFAULT_PREC indicates that a computational precision
+ * should be used which is not less than that of any of the input or output operands, but not typically greater than
+ * that of any input or output operand (except for low-precision types as noted). For example, the multiplication
+ * of float32 and float64 scalars accumulated into a float64 scalar could be performed in either f32f32_accum_f32
+ * or f64f64_accum_f64 precision. The first option would require conversion of float64->float32 for one input operand
+ * and float32->float64 during accumulation, while the second option would require float32->float64 conversion of the
+ * other input operand.
+ *
+ * The computational precision indicates the precision of accumulation for a single scalar product, which may or may
+ * not be maintained accross a large number of scalar operations. Any additional accumulation, e.g. from registers
+ * to memory, or additional scalar multiplications such as multiplication by beta in a tensor contraction will be
+ * performed in a precision greater than or equal to the precision of the storage data type of the output operand,
+ * even if this precision is less than the indicated computational precision. For example, register-to-memory
+ * accumulation for an output of type float16 may use float16 arithmetic even if the computational precision is
+ * f16f16_accum_f32.
+ */
+
+typedef int TAPP_prectype;
+
+enum
+{
+    /* The computational precision is determined as *at least* the lowest precision of the storage data types */
+    /* of all input and output operands. */
+    TAPP_DEFAULT_PREC = -1,
+
+    /* IEEE754 float32 with or without singly-rounded FMA */
+    TAPP_F32F32_ACCUM_F32 = TAPP_F32, /* = 0 */
+
+    /* IEEE754 float64 with or without singly-rounded FMA */
+    TAPP_F64F64_ACCUM_F64 = TAPP_F64, /* = 1 */
+
+    /* IEEE754 float16 with or without singly-rounded FMA */
+    /* Implementations may compute final or intermediate results in a higher precision */
+    TAPP_F16F16_ACCUM_F16 = TAPP_F16, /* = 3 */
+
+    /* float16 with wide accumulation */
+    /* Implementations may compute intermediate results in a higher precision */
+    TAPP_F16F16_ACCUM_F32 = 5,
+
+    /* bfloat16 with wide accumulation */
+    TAPP_BF16BF16_ACCUM_F32 = 6,
+};
+
+#endif /* TAPP_DATATYPE_H_ */

--- a/src/tapp/error.h
+++ b/src/tapp/error.h
@@ -1,0 +1,26 @@
+#ifndef TAPP_ERROR_H_
+#define TAPP_ERROR_H_
+
+#include <stddef.h>
+#include <stdbool.h>
+
+typedef int TAPP_error;
+
+/* Return true if the error code indicates success and false otherwise. */
+bool TAPP_check_success(TAPP_error error);
+
+/*
+ * Fill a user-provided buffer with an implementation-defined string explaining the error code. No more than maxlen-1
+ * characters will be written. If maxlen is greater than zero, then a terminating null character is also
+ * written. The actual number of characters written is returned, not including the terminating null character.
+ * If maxlen is zero, then no characters are written and instead the length of the full string which would have been
+ * written is returned, not including the terminating null character. This means that the message written will always
+ * be null-terminated.
+ *
+ * TODO: should the null character be included in the return value?
+ */
+size_t TAPP_explain_error(TAPP_error error,
+                          size_t maxlen,
+                          char* message);
+
+#endif /* TAPP_ERROR_H_ */

--- a/src/tapp/executor.h
+++ b/src/tapp/executor.h
@@ -1,0 +1,17 @@
+#ifndef TAPP_EXECUTOR_H_
+#define TAPP_EXECUTOR_H_
+
+#include <stdint.h>
+
+#include "error.h"
+
+typedef intptr_t TAPP_executor;
+
+/*
+ * TODO: implementation-defined creation of executors or "wrapper" to get all implementations and select one?
+ *       devices probably can't be enumerated until you have a handle....
+ */
+
+TAPP_error TAPP_destroy_executor(TAPP_executor exec);
+
+#endif /* TAPP_HANDLE_H_ */

--- a/src/tapp/handle.h
+++ b/src/tapp/handle.h
@@ -1,0 +1,23 @@
+#ifndef TAPP_HANDLE_H_
+#define TAPP_HANDLE_H_
+
+#include <stdint.h>
+
+#include "error.h"
+
+typedef intptr_t TAPP_handle;
+
+/*
+ * TODO: implementation-defined creation of handles or "wrapper" to get all implementations and select one?
+ *       devices probably can't be enumerated until you have a handle....
+ */
+
+ //TODO: get string describing implementation?
+
+ //TODO: API versioning and query
+
+ //TODO: optional APIs with feature test macros
+
+TAPP_error TAPP_destroy_handle(TAPP_handle handle);
+
+#endif /* TAPP_HANDLE_H_ */

--- a/src/tapp/product.h
+++ b/src/tapp/product.h
@@ -24,11 +24,18 @@ enum
 
 /*
  * TODO: what are the required error conditions?
+ *
  * TODO: must C and D info be the same? (should they just be the same variable?)
+ *  JB: Can this be implemented efficiently with different data types of C and D? 
+ *      Let’s say D is complex and C real. Then it should be possible with a different "stride".
+ *      In such cases we might want to support different C and D info. If D info is null, they 
+ *      are assumed identical. 
  */
 
 typedef intptr_t TAPP_tensor_product;
 
+// D_{idx_D} = alpha * A_{idx_A} * B_{idx_B} + beta * C_{idx_C}
+// each idx is an array of einsum style index "characters", e.g. {'a', 'b', 'i', 'j'}
 TAPP_error TAPP_create_tensor_product(TAPP_tensor_product* plan,
                                       TAPP_handle handle,
                                       TAPP_element_op op_A,
@@ -72,5 +79,7 @@ TAPP_error TAPP_execute_batched_product(TAPP_tensor_product plan,
                                         const void* beta,
                                         const void** C,
                                               void** D);
+
+//JB: TODO: variable sized batching (DM suggests plan of plans)
 
 #endif /* TAPP_PRODUCT_H_ */

--- a/src/tapp/product.h
+++ b/src/tapp/product.h
@@ -1,0 +1,76 @@
+#ifndef TAPP_PRODUCT_H_
+#define TAPP_PRODUCT_H_
+
+#include <stdint.h>
+
+#include "error.h"
+#include "handle.h"
+#include "executor.h"
+#include "datatype.h"
+#include "status.h"
+#include "tensor.h"
+
+//TODO: where should this go?
+typedef int TAPP_element_op;
+
+enum
+{
+    TAPP_IDENTITY = 0,
+    TAPP_CONJUGATE = 1,
+};
+
+//TODO: where should this go?
+#define TAPP_IN_PLACE NULL
+
+/*
+ * TODO: what are the required error conditions?
+ * TODO: must C and D info be the same? (should they just be the same variable?)
+ */
+
+typedef intptr_t TAPP_tensor_product;
+
+TAPP_error TAPP_create_tensor_product(TAPP_tensor_product* plan,
+                                      TAPP_handle handle,
+                                      TAPP_element_op op_A,
+                                      TAPP_tensor_info A,
+                                      const int64_t* idx_A,
+                                      TAPP_element_op op_B,
+                                      TAPP_tensor_info B,
+                                      const int64_t* idx_B,
+                                      TAPP_element_op op_C,
+                                      TAPP_tensor_info C,
+                                      const int64_t* idx_C,
+                                      TAPP_element_op op_D,
+                                      TAPP_tensor_info D,
+                                      const int64_t* idx_D,
+                                      TAPP_prectype prec);
+
+TAPP_error TAPP_destory_tensor_product(TAPP_tensor_product plan);
+
+//TODO: in-place operation: set C = NULL or TAPP_IN_PLACE?
+
+TAPP_error TAPP_execute_product(TAPP_tensor_product plan,
+                                TAPP_executor exec,
+                                TAPP_status* status,
+                                const void* alpha,
+                                const void* A,
+                                const void* B,
+                                const void* beta,
+                                const void* C,
+                                      void* D);
+
+//TODO: is it always OK to pass NULL for exec?
+//TODO: can C be NULL/TAPP_IN_PLACE (in addition to array entries being NULL)?
+
+TAPP_error TAPP_execute_batched_product(TAPP_tensor_product plan,
+                                        TAPP_executor exec,
+                                        TAPP_status* status,
+                                        int num_batches,
+                                        const void* alpha,
+                                        const void** A,
+                                        const void** B,
+                                        const void* beta,
+                                        const void** C,
+                                              void** D);
+
+#endif /* TAPP_PRODUCT_H_ */

--- a/src/tapp/product.h
+++ b/src/tapp/product.h
@@ -52,7 +52,7 @@ TAPP_error TAPP_create_tensor_product(TAPP_tensor_product* plan,
                                       const int64_t* idx_D,
                                       TAPP_prectype prec);
 
-TAPP_error TAPP_destory_tensor_product(TAPP_tensor_product plan);
+TAPP_error TAPP_destroy_tensor_product(TAPP_tensor_product plan);
 
 //TODO: in-place operation: set C = NULL or TAPP_IN_PLACE?
 

--- a/src/tapp/status.h
+++ b/src/tapp/status.h
@@ -1,0 +1,18 @@
+#ifndef TAPP_STATUS_H_
+#define TAPP_STATUS_H_
+
+#include <stdint.h>
+
+#include "error.h"
+
+typedef intptr_t TAPP_status;
+
+/*
+ * Status objects are created by execution functions (e.g. TAPP_execute_product).
+ *
+ * TODO: how to get data out? using attributes or separate standardized interface? implementation-defined?
+ */
+
+TAPP_error TAPP_destroy_status(TAPP_status status);
+
+#endif /* TAPP_STATUS_H_ */

--- a/src/tapp/tensor.h
+++ b/src/tapp/tensor.h
@@ -1,0 +1,40 @@
+#ifndef TAPP_TENSOR_H_
+#define TAPP_TENSOR_H_
+
+#include <stdint.h>
+
+#include "error.h"
+#include "datatype.h"
+
+typedef intptr_t TAPP_tensor_info;
+
+/*
+ * TODO: what are the required error conditions? What is explicitly allowed (esp. regarding strides)?
+ */
+
+TAPP_error TAPP_create_tensor_info(TAPP_tensor_info* info,
+                                   TAPP_datatype type,
+                                   int nmode,
+                                   const int64_t* extents,
+                                   const int64_t* strides);
+
+TAPP_error TAPP_destory_tensor_info(TAPP_tensor_info info);
+
+int TAPP_get_nmodes(TAPP_tensor_info info);
+
+TAPP_error TAPP_set_nmodes(TAPP_tensor_info info,
+                           int nmodes);
+
+void TAPP_get_extents(TAPP_tensor_info info,
+                      int64_t* extents);
+
+TAPP_error TAPP_set_extents(TAPP_tensor_info info,
+                            const int64_t* extents);
+
+void TAPP_get_strides(TAPP_tensor_info info,
+                      int64_t* strides);
+
+TAPP_error TAPP_set_strides(TAPP_tensor_info info,
+                            const int64_t* strides);
+
+#endif /* TAPP_TENSOR_H_ */

--- a/src/tapp/tensor.h
+++ b/src/tapp/tensor.h
@@ -18,7 +18,7 @@ TAPP_error TAPP_create_tensor_info(TAPP_tensor_info* info,
                                    const int64_t* extents,
                                    const int64_t* strides);
 
-TAPP_error TAPP_destory_tensor_info(TAPP_tensor_info info);
+TAPP_error TAPP_destroy_tensor_info(TAPP_tensor_info info);
 
 int TAPP_get_nmodes(TAPP_tensor_info info);
 


### PR DESCRIPTION
The draft standard includes opaque objects for tensor info (descriptors), library handles, executors (stream/device), plans, and statuses. The attributes interface can set or get attributes any of these (except the latter?), while errors are returned as a simple error code.